### PR TITLE
minor fixes for LOVE2D 11.x

### DIFF
--- a/PreviousParts/Part4/SoftEngine.lua
+++ b/PreviousParts/Part4/SoftEngine.lua
@@ -178,7 +178,6 @@ function SoftEngine.Device:render(camera, meshes)
 			local pixelC = self:project(vertexC, transformMatrix)
 			
 			local color = 0.25 + ((k % #cMesh.faces) / #cMesh.faces) * 0.75
-			color = BABYLON.remap(color, 0, 1, 0, 255)
 		
 			self:drawTriangle(pixelA, pixelB, pixelC, BABYLON.Color4(color, color, color, 255))
 		end

--- a/PreviousParts/Part5/SoftEngine.lua
+++ b/PreviousParts/Part5/SoftEngine.lua
@@ -235,7 +235,7 @@ function SoftEngine.Device:render(camera, meshes)
 			local pixelB = self:project(vertexB, transformMatrix, worldMatrix)
 			local pixelC = self:project(vertexC, transformMatrix, worldMatrix)
 			
-			local color = 255
+			local color = 1
 		
 			self:drawTriangle(pixelA, pixelB, pixelC, BABYLON.Color4(color, color, color, 255))
 		end


### PR DESCRIPTION
I've never really used LOVE2D before, and I only looked at your code briefly, so I don't know why these changes are needed.

But, without these fixes some parts look broken:

*Part 4* (alternating colours blown out to white)
<img width="800" alt="Screen shot 2021-09-27 at 13 27 05" src="https://user-images.githubusercontent.com/49612/134908017-675b7bd7-0a9e-4143-918e-2e63afb49820.png">

*Part 5* (Gouraud shading blown out to white/black)
<img width="800" alt="Screen shot 2021-09-27 at 13 30 00" src="https://user-images.githubusercontent.com/49612/134908251-8efc4cf0-080b-4fa8-9495-e51e5edb7e94.png">
 
